### PR TITLE
[DRAFT] Improve documentation and apply clippy lints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-# `tower-sessions-surrealdb-store`
+<h1 align="center">
+    tower-sessions-surrealdb-store
+</h1>
+
+<p align="center">
+    SurrealDB session stores for `tower-sessions`.
+</p>
 
 This package is in beta. It has automated tests for the basic functionality, but is untested in production.
 
-See `examples/counter.rs` for usage.
+## 🎨 Overview
+
+- **Compact encoding**: session data is stored in
+  the database using [MessagePack](https://crates.io/crates/rmp-serde),
+  a compact self-describing serialization format.
+- **Automatic table setup**: only provide a database connection and a table name;
+  the table will be created if it does not exist.
 
 ## Using `surrealdb-nightly`
 
@@ -10,7 +22,54 @@ In `Config.toml`:
 
 ```toml
 tower-sessions-surrealdb-store = { version = "*", features = ["surrealdb-nightly"], default-features = false }
-
 ```
 
 The `default-features = false` is necessary, otherwise you'll install both `surrealdb` and `surrealdb-nightly` and get conflicts.
+
+## 🤸 Usage Example
+See `examples/counter.rs` for the full example.
+
+```rust
+#[tokio::main]
+async fn main() {
+    let db = surrealdb::Surreal::new::<surrealdb::engine::local::Mem>(())
+        .await
+        .expect("Surreal initialization failure");
+    db.use_ns("testing")
+        .await
+        .expect("Surreal namespace initialization failure");
+    db.use_db("testing")
+        .await
+        .expect("Surreal database initialization failure");
+
+    // This sets up the store to use the `sessions` table.
+    let session_store = SurrealSessionStore::new(db.clone(), "sessions".to_string());
+    let expired_session_cleanup_interval: u64 = 1;
+    tokio::task::spawn(session_store.clone().continuously_delete_expired(
+        tokio::time::Duration::from_secs(60 * expired_session_cleanup_interval),
+    ));
+
+    let session_service = ServiceBuilder::new().layer(
+        SessionManagerLayer::new(session_store)
+            .with_secure(false)
+            .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
+    );
+
+    let app = Router::new()
+        .route("/", get(handler))
+        .layer(session_service);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("Listening on {addr}");
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    axum::serve(listener, app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn handler(session: Session) -> impl IntoResponse {
+    let counter: Counter = session.get(COUNTER_KEY).await.unwrap().unwrap_or_default();
+    session.insert(COUNTER_KEY, counter.0 + 1).await.unwrap();
+    format!("Current count: {}", counter.0)
+}
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-    SurrealDB session stores for `tower-sessions`.
+    SurrealDB session stores for <code>tower-sessions</code>.
 </p>
 
 This package is in beta. It has automated tests for the basic functionality, but is untested in production.
@@ -27,49 +27,5 @@ tower-sessions-surrealdb-store = { version = "*", features = ["surrealdb-nightly
 The `default-features = false` is necessary, otherwise you'll install both `surrealdb` and `surrealdb-nightly` and get conflicts.
 
 ## 🤸 Usage Example
-See `examples/counter.rs` for the full example.
+See `examples/counter.rs`.
 
-```rust
-#[tokio::main]
-async fn main() {
-    let db = surrealdb::Surreal::new::<surrealdb::engine::local::Mem>(())
-        .await
-        .expect("Surreal initialization failure");
-    db.use_ns("testing")
-        .await
-        .expect("Surreal namespace initialization failure");
-    db.use_db("testing")
-        .await
-        .expect("Surreal database initialization failure");
-
-    // This sets up the store to use the `sessions` table.
-    let session_store = SurrealSessionStore::new(db.clone(), "sessions".to_string());
-    let expired_session_cleanup_interval: u64 = 1;
-    tokio::task::spawn(session_store.clone().continuously_delete_expired(
-        tokio::time::Duration::from_secs(60 * expired_session_cleanup_interval),
-    ));
-
-    let session_service = ServiceBuilder::new().layer(
-        SessionManagerLayer::new(session_store)
-            .with_secure(false)
-            .with_expiry(Expiry::OnInactivity(Duration::seconds(10))),
-    );
-
-    let app = Router::new()
-        .route("/", get(handler))
-        .layer(session_service);
-
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    println!("Listening on {addr}");
-    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    axum::serve(listener, app.into_make_service())
-        .await
-        .unwrap();
-}
-
-async fn handler(session: Session) -> impl IntoResponse {
-    let counter: Counter = session.get(COUNTER_KEY).await.unwrap().unwrap_or_default();
-    session.insert(COUNTER_KEY, counter.0 + 1).await.unwrap();
-    format!("Current count: {}", counter.0)
-}
-```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,10 @@ impl<DB: std::fmt::Debug + surrealdb::Connection> ExpiredDeletion for SurrealSes
     async fn delete_expired(&self) -> Result<()> {
         info!("Deleting expired sessions");
         self.client
-            .query(format!(
+            .query(
                 "delete type::table($table) where expiry_date <= time::unix(time::now())"
-            ))
+                    .to_string(),
+            )
             .bind(("table", self.session_table.clone()))
             .await
             .map_err(|e| Error::Backend(e.to_string()))?
@@ -164,8 +165,8 @@ mod test {
         let not_expired2 = make_record(None, [("key", "value")].to_vec(), Duration::minutes(1));
 
         for session in [&expired, &expired2, &not_expired, &not_expired2] {
-            save_session(&store, &session).await;
-            select_session(&db, &session)
+            save_session(&store, session).await;
+            select_session(&db, session)
                 .await
                 .expect("Session should be in the database");
         }
@@ -176,11 +177,11 @@ mod test {
             .expect("Error deleting expired");
 
         for not_expired in [&not_expired, &not_expired2] {
-            select_session(&db, &not_expired)
+            select_session(&db, not_expired)
                 .await
                 .expect("Not-expired session should be in the database");
 
-            let loaded = load_session(&store, &not_expired)
+            let loaded = load_session(&store, not_expired)
                 .await
                 .expect("No session loaded");
 
@@ -191,13 +192,13 @@ mod test {
         }
 
         for expired in [&expired, &expired2] {
-            let loaded = select_session(&db, &expired).await;
+            let loaded = select_session(&db, expired).await;
             assert!(
                 loaded.is_none(),
                 "Expired session should not be in the database"
             );
 
-            let loaded = load_session(&store, &expired).await;
+            let loaded = load_session(&store, expired).await;
 
             assert!(
                 loaded.is_none(),
@@ -324,7 +325,7 @@ mod test {
     }
 
     async fn make_session_record(session: &Record) -> SessionRecord {
-        SessionRecord::from_session(&session).expect("Error deserializing")
+        SessionRecord::from_session(session).expect("Error deserializing")
     }
 
     async fn save_session(store: &SurrealSessionStore<DB>, session: &Record) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use tower_sessions_core::{
 };
 use tracing::info;
 
+#[cfg(all(feature="surrealdb", feature="surrealdb-nightly"))]
+compile_error!{"Features 'surrealdb' and 'surrealdb-nightly' must not be enabled at the same time! See the README for details."}
+
 /// Representation of a session in the database.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct SessionRecord {


### PR DESCRIPTION
This fixes #7 by changing the README to follow the style of the other session stores like https://github.com/maxcountryman/tower-sessions-stores/blob/main/sqlx-store/README.md

I also applied some clippy lints and added a compile error with additional info for the case of incompatible features.

Please let me know what you think, I am open to make more changes as required.