### PR TITLE
Handle case where upsert() returns Ok(None) in save

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,14 +85,12 @@ impl<DB: std::fmt::Debug + surrealdb::Connection> SessionStore for SurrealSessio
     }
 
     async fn save(&self, session: &Record) -> Result<()> {
-        let _: SessionRecord = self
+        let _: Option<SessionRecord> = self
             .client
             .upsert((self.session_table.clone(), session.id.to_string()))
             .content(SessionRecord::from_session(session)?)
             .await
-            .map_err(|e| Error::Backend(e.to_string()))?
-            .ok_or(Error::Backend("Session record not saved".to_string()))?;
-
+            .map_err(|e| Error::Backend(e.to_string()))?;
         Ok(())
     }
 


### PR DESCRIPTION
Observed behaviour in SurrealDB 3.0.x is that when connecting to the a remote database with the ws:// protocol, upsert() returns Option::None even in the case where the command succeded.