### PR TITLE
Allow sharing Surreal client with session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ The `default-features = false` is necessary, otherwise you'll install both `surr
 ## 🤸 Usage Example
 See `examples/counter.rs`.
 
+`SurrealSessionStore::new` now accepts either an owned `Surreal<DB>` client or an
+`Arc<Surreal<DB>>` which can be used to share single `Surreal<DB>` instance between the session store and some other
+parts of an application. With the recent changes in
+[clone semantics in SurrealDB 3](https://surrealdb.com/docs/languages/rust/concepts/multi-tenancy) it might be useful
+to share instances in this way. For example, if authentication is done using short-lived tokens it might be useful
+to be able to have code outside the session store refresh the token, something that is not spported when passing
+owneship of the `Surreal<DB>` instance to the session store.

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -3,7 +3,7 @@
 //! second cookie lifetime. Go to the URL shown in the console in your
 //! browser, the counter should increment on each page load, and after
 //! 10 seconds of inactivity the counter should reset.
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 
 use axum::{response::IntoResponse, routing::get, Router};
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,7 @@ async fn main() {
     db.use_db("testing")
         .await
         .expect("Surreal database initialization failure");
+    let db = Arc::new(db);
 
     // This sets up the store to use the `sessions` table.
     let session_store = SurrealSessionStore::new(db.clone(), "sessions".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::sync::Arc;
 use surrealdb::{types::SurrealValue, Surreal};
 use tower_sessions_core::{
     session::{Id, Record},
@@ -35,7 +36,7 @@ impl SessionRecord {
 /// A SurrealDB session store.
 #[derive(Debug, Clone)]
 pub struct SurrealSessionStore<DB: std::fmt::Debug + surrealdb::Connection> {
-    client: Surreal<DB>,
+    client: Arc<Surreal<DB>>,
     session_table: String,
 }
 
@@ -43,9 +44,14 @@ impl<DB: std::fmt::Debug + surrealdb::Connection> SurrealSessionStore<DB> {
     /// Create a new SurrealDB session store with the provided client,
     /// storing sessions in the given table. Note that the table must
     /// be defined ahead of time if strict mode is enabled.
-    pub fn new(client: Surreal<DB>, session_table: String) -> Self {
+    ///
+    /// The client may be either an owned [`Surreal`] instance or an
+    /// [`Arc<Surreal<_>>`](Arc). Passing an `Arc` lets application code and the
+    /// session store share the same SurrealDB client, so re-authentication on
+    /// that client is visible to store operations.
+    pub fn new(client: impl Into<Arc<Surreal<DB>>>, session_table: String) -> Self {
         Self {
-            client,
+            client: client.into(),
             session_table,
         }
     }
@@ -124,7 +130,7 @@ where expiry_date > time::unix(time::now())",
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
 
     use tower_sessions::cookie::time::{Duration, OffsetDateTime};
 
@@ -155,6 +161,24 @@ mod test {
         save_session(&store, &record).await;
         let loaded = load_session(&store, &record).await.expect("Value missing");
         assert_eq!(record, loaded, "Loaded value should equal original");
+    }
+
+    #[tokio::test]
+    async fn accepts_shared_surreal_client() {
+        let db = Arc::new(new_db_connection().await);
+        let store = SurrealSessionStore::new(db.clone(), SESSIONS_TABLE.to_string());
+        let record = make_record(None, [("key", "value")].to_vec(), Duration::days(1));
+
+        save_session(&store, &record).await;
+
+        let stored = select_session(&db, &record)
+            .await
+            .expect("Session should be visible through shared client");
+        let expected = make_session_record(&record).await;
+        assert_eq!(
+            expected, stored,
+            "Shared Surreal client should see saved session"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
One issue that has surfaced when running tower-sessions-surrealdb-store with surreal v3 is that authentication tokens stored in the database client are now local to the specific cloned `Surreal<DB>` instance instead of shared between all clones.

This caused some hard-to-debug authentication problems, as the session store re-authantication only seems to happen in the rare cases when the connection to the database was severed.

This change enables users of short lived tokens for authentication to be able to refresh the token held by the `Surreal<DB>` instance