### PR TITLE
Update surrealdb dependency to 3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ repository = "https://github.com/rynoV/tower-sessions-surrealdb-store"
 documentation = "https://docs.rs/tower-sessions-surrealdb-store"
 readme = "README.md"
 resolver = "2"
-rust-version = "1.90.0"
+rust-version = "1.92.0"
 
 [dependencies]
 async-trait = "0.1.89"
 rmp-serde = "1.0.0"
-surrealdb = { version = "3.0.0" }
+surrealdb = { version = "3.1" }
 tower-sessions-core = { version = "0.14.0", features = ["deletion-task"] }
 tracing = "0.1.44"
 
@@ -30,7 +30,7 @@ tokio = "1.44.2"
 tokio-test = "0.4.4"
 tower = "0.5.2"
 tower-sessions = "0.14.0"
-surrealdb = { version = "3.0.0", features = ["kv-mem"] }
+surrealdb = { version = "3.1", features = ["kv-mem"] }
 
 [[example]]
 name = "counter"


### PR DESCRIPTION
Thank you so much for the 3.0 release! However, upstream seemingly never sleeps, and has released SurrealDB 3.1. As far as I can tell from some causal testing using https://github.com/nresare/idelephant it seems to be working just fine with this project as long as the dependency updated.

There are also some other components that would need updating, but I guess I can put that in a separate diff