### PR TITLE
Move to using surrealdb::types::Bytes for the session data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ mod test {
         db.use_db("testing")
             .await
             .expect("Surreal database initialization failure");
-        db.query("DEFINE table $table")
+        db.query("DEFINE TABLE $table SCHEMAFULL; DEFINE FIELD data ON TABLE $table TYPE bytes; DEFINE FIELD expiry_date ON TABLE $table TYPE int;")
             .bind(("table", SESSIONS_TABLE))
             .await
             .expect("Failed to define table");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,32 @@ mod test {
     }
 
     #[tokio::test]
+    async fn schema() {
+        let db = new_db_connection().await;
+        let store = SurrealSessionStore::new(db.clone(), SESSIONS_TABLE.to_string());
+        let record = make_record(None, [("key", "value")].to_vec(), Duration::days(1));
+        save_session(&store, &record).await;
+        let type_of_data: Option<String> = db
+            .query("select value type::of(data) from only type::record($table, $id)")
+            .bind(("id", record.id.to_string()))
+            .bind(("table", SESSIONS_TABLE))
+            .await
+            .expect("Failed to get type")
+            .take(0)
+            .expect("Failed to get result");
+        assert_eq!(type_of_data, Some("bytes".to_string()));
+        let type_of_expiry_date: Option<String> = db
+            .query("select value type::of(expiry_date) from only type::record($table, $id)")
+            .bind(("id", record.id.to_string()))
+            .bind(("table", SESSIONS_TABLE))
+            .await
+            .expect("Failed to get expiry_date")
+            .take(0)
+            .expect("Failed to get result");
+        assert_eq!(type_of_expiry_date, Some("int".to_string()));
+    }
+
+    #[tokio::test]
     async fn basic_roundtrip() {
         let db = new_db_connection().await;
         let store = SurrealSessionStore::new(db.clone(), SESSIONS_TABLE.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use std::sync::Arc;
+use surrealdb::types::Bytes;
 use surrealdb::{types::SurrealValue, Surreal};
 use tower_sessions_core::{
     session::{Id, Record},
@@ -11,14 +12,17 @@ use tracing::info;
 /// Representation of a session in the database.
 #[derive(SurrealValue, Debug, PartialEq)]
 struct SessionRecord {
-    data: Vec<u8>,
+    data: Bytes,
     expiry_date: i64,
 }
 
 impl SessionRecord {
     fn from_session(session: &Record) -> Result<Self> {
+        let data = rmp_serde::to_vec(&session)
+            .map_err(|e| Error::Decode(e.to_string()))?
+            .into();
         Ok(SessionRecord {
-            data: rmp_serde::to_vec(session).map_err(|e| Error::Decode(e.to_string()))?,
+            data,
             expiry_date: session.expiry_date.unix_timestamp(),
         })
     }


### PR DESCRIPTION
With the changes in SurrealDB 3, a Vec of u8 no longer gets stored in a byte vector type in the database. Instead it is stored as a list of small integers, which is not very efficient. This change makes sure that we store a SurrealDB Bytes type which is stored more efficiently and with fewer SurrealQL semantic surprises.